### PR TITLE
Cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,10 +13,14 @@ if (TARGET tinyusb_device)
 
     add_executable(SmileStick
         main.c
+        core2.c
     )
 
     # Add pico_stdlib library which aggregates commonly used features
-    target_link_libraries(SmileStick pico_stdlib)
+    target_link_libraries(SmileStick 
+        pico_multicore 
+        pico_stdlib
+    )
 
     # enable usb output, disable uart output
     pico_enable_stdio_usb(SmileStick 1)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # SmileStick
 
+* Cleanup branch is work in progress to make some nicer code.
+
 This is my repository for my experiments in using a pi pico to control a VTech v.SMILE controller.
 
 

--- a/core2.c
+++ b/core2.c
@@ -1,7 +1,5 @@
 #include <stdio.h>
 #include "pico/stdlib.h"
-#include "pico/util/queue.h"
-#include "pico/multicore.h"
 #include "core2.h"
 
 
@@ -16,15 +14,15 @@ void coreUSBMain() {
 
         if (stickData.length == 1)
         {
-            printfn("Received message of length %d, %d.", stickData.length, stickData.message[0]);
+            printf("Received message of length %d, %d.\r\n", stickData.length, stickData.message[0]);
         }
-        else if (stickData.length == 1)
+        else if (stickData.length == 2)
         {
-            printfn("Received message of length %d, %d, %d.", stickData.length, stickData.message[0], stickData.message[1]);
+            printf("Received message of length %d, %d, %d.\r\n", stickData.length, stickData.message[0], stickData.message[1]);
         }
         else
         {
-            printfn("Received message of length %d.", stickData.length);
+            printf("Received message of length %d.\r\n", stickData.length);
         }
         //int32_t (*func)() = (int32_t(*)())(entry.func);
         //int32_t result = (*func)(entry.data);

--- a/core2.c
+++ b/core2.c
@@ -1,0 +1,34 @@
+#include <stdio.h>
+#include "pico/stdlib.h"
+#include "pico/util/queue.h"
+#include "pico/multicore.h"
+#include "core2.h"
+
+
+void coreUSBMain() {
+    while (1) {
+        // Controller data is passed to us via the stickData_t which contains 
+        // the data and the length of the data.
+        
+        stickData_t stickData;
+
+        queue_remove_blocking(&call_queue, &stickData);
+
+        if (stickData.length == 1)
+        {
+            printfn("Received message of length %d, %d.", stickData.length, stickData.message[0]);
+        }
+        else if (stickData.length == 1)
+        {
+            printfn("Received message of length %d, %d, %d.", stickData.length, stickData.message[0], stickData.message[1]);
+        }
+        else
+        {
+            printfn("Received message of length %d.", stickData.length);
+        }
+        //int32_t (*func)() = (int32_t(*)())(entry.func);
+        //int32_t result = (*func)(entry.data);
+
+        //queue_add_blocking(&results_queue, &result);
+    }
+}

--- a/core2.c
+++ b/core2.c
@@ -12,21 +12,95 @@ void coreUSBMain() {
 
         queue_remove_blocking(&call_queue, &stickData);
 
-        if (stickData.length == 1)
+        // if (stickData.length == 1)
+        // {
+        //     printf("Received message of length %d, 0x%x.\r\n", stickData.length, stickData.message[0]);
+        // }
+        // else if (stickData.length == 2)
+        // {
+        //     printf("Received message of length %d, 0x%x, 0x%x.\r\n", stickData.length, stickData.message[0], stickData.message[1]);
+        // }
+        // else
+        // {
+        //     printf("Received message of length %d.\r\n", stickData.length);
+        // }
+
+        for (int i = 0; i < stickData.length; i++)
         {
-            printf("Received message of length %d, %d.\r\n", stickData.length, stickData.message[0]);
+            if ((stickData.message[i] & 0xF0) == 0xC0)
+            {
+                x = (stickData.message[i] & 0x0F);
+            }
+            if ((stickData.message[i] & 0xF0) == 0x80)
+            {
+                y = (stickData.message[i] & 0x0F);
+            }
+            if ((stickData.message[i] & 0xF0) == 0x90)
+            {
+                greenButton = (stickData.message[i] & 0x01) ? true : false;
+                blueButton = (stickData.message[i] & 0x02) ? true : false;
+                yellowButton = (stickData.message[i] & 0x04) ? true : false;
+                redButton = (stickData.message[i] & 0x08) ? true : false;
+            }
+            if ((stickData.message[i] & 0xF0) == 0xA0)
+            {
+                if ((stickData.message[i] & 0x0F) == 0x3)
+                {
+                    helpButton = true;
+                    enterButton = false;
+                    exitButton = false;
+                    learningZoneButton = false;
+                }
+                else if ((stickData.message[i] & 0x0F) == 0x1)
+                {
+                    helpButton = false;
+                    enterButton = true;
+                    exitButton = false;
+                    learningZoneButton = false;
+                }
+                else if ((stickData.message[i] & 0x0F) == 0x2)
+                {
+                    helpButton = false;
+                    enterButton = false;
+                    exitButton = true;
+                    learningZoneButton = false;
+                }
+                else if ((stickData.message[i] & 0x0F) == 0x4)
+                {
+                    helpButton = false;
+                    enterButton = false;
+                    exitButton = false;
+                    learningZoneButton = true;
+                }
+                else 
+                { 
+                    helpButton = false;
+                    enterButton = false;
+                    exitButton = false;
+                    learningZoneButton = false;                 
+                }
+            }
+        
         }
-        else if (stickData.length == 2)
-        {
-            printf("Received message of length %d, %d, %d.\r\n", stickData.length, stickData.message[0], stickData.message[1]);
-        }
-        else
-        {
-            printf("Received message of length %d.\r\n", stickData.length);
-        }
+        printState();
         //int32_t (*func)() = (int32_t(*)())(entry.func);
         //int32_t result = (*func)(entry.data);
 
         //queue_add_blocking(&results_queue, &result);
     }
+}
+
+void printState() {
+	printf(redButton ? "R1 " : "R0 ");
+    printf(yellowButton ? "Y1 " : "Y0 ");
+    printf(blueButton ? "B1 " : "B0 ");
+    printf(greenButton ? "G1 " : "G0 ");
+    printf(enterButton ? "e1 " : "e0 ");
+    printf(helpButton ? "h1 " : "h0 ");
+    printf(exitButton ? "x1 " : "x0 ");
+    printf(learningZoneButton ? "l1 " : "l0 ");
+    printf(" | ");
+    printf("%d", x);
+    printf(", ");
+    printf("%d\r\n", y);
 }

--- a/core2.h
+++ b/core2.h
@@ -1,0 +1,13 @@
+
+
+typedef struct
+{
+    char message[10];
+    int8_t length;
+} stickData_t;
+
+queue_t call_queue;
+//queue_t results_queue;
+
+
+void coreUSBMain();

--- a/core2.h
+++ b/core2.h
@@ -3,8 +3,19 @@
 #include "pico/multicore.h"
 
 
+void printState();
 
 extern queue_t call_queue;
 //queue_t results_queue;
 
 
+static bool redButton = false;
+static bool yellowButton = false;
+static bool blueButton = false;
+static bool greenButton = false;
+static bool enterButton = false;
+static bool helpButton = false;
+static bool exitButton = false;
+static bool learningZoneButton = false;
+static char x = 0;
+static char y = 0;

--- a/core2.h
+++ b/core2.h
@@ -1,13 +1,10 @@
+#include "shared.h"
+#include "pico/util/queue.h"
+#include "pico/multicore.h"
 
 
-typedef struct
-{
-    char message[10];
-    int8_t length;
-} stickData_t;
 
-queue_t call_queue;
+extern queue_t call_queue;
 //queue_t results_queue;
 
 
-void coreUSBMain();

--- a/main.h
+++ b/main.h
@@ -1,0 +1,14 @@
+
+#include <stdio.h>
+#include <string.h>
+#include "shared.h"
+#include "pico/stdlib.h"
+#include "pico/util/queue.h"
+#include "pico/multicore.h"
+
+
+
+
+queue_t call_queue;
+
+bool sendByte(char data);

--- a/shared.h
+++ b/shared.h
@@ -1,0 +1,9 @@
+#include <stdio.h>
+
+typedef struct
+{
+    char message[10];
+    int8_t length;
+} stickData_t;
+
+void coreUSBMain();


### PR DESCRIPTION
This code should be a little nicer. Its no longer a 100% match for the console trace, but it still functions.

One major difference is that CTS now moves opposite to RTS. It doesn't keep CTS low until after the last receive char. The console does that, but it does not seem necessary.
Also eliminated almost all delays and have things fully interrupt driven. The controller does not seem to mind the packets being closer together. Don't know why the console games add so much delay. maybe they assume children don't need fine control :)